### PR TITLE
Support isCancelled and isPending in the CompletePurchaseResponse

### DIFF
--- a/src/Omnipay/Adyen/Message/CompletePurchaseResponse.php
+++ b/src/Omnipay/Adyen/Message/CompletePurchaseResponse.php
@@ -47,4 +47,15 @@ class CompletePurchaseResponse extends AbstractResponse
 
         return $data['authResult'] === 'CANCELLED';
     }
+
+    public function isPending()
+    {
+        $data = ($this->getData());
+
+        if (!isset($data['authResult'])) {
+            return false;
+        }
+
+        return $data['authResult'] === 'PENDING';
+    }
 }

--- a/src/Omnipay/Adyen/Message/CompletePurchaseResponse.php
+++ b/src/Omnipay/Adyen/Message/CompletePurchaseResponse.php
@@ -41,6 +41,10 @@ class CompletePurchaseResponse extends AbstractResponse
     {
         $data = ($this->getData());
 
+        if (!isset($data['authResult'])) {
+            return false;
+        }
+
         return $data['authResult'] === 'CANCELLED';
     }
 }

--- a/src/Omnipay/Adyen/Message/CompletePurchaseResponse.php
+++ b/src/Omnipay/Adyen/Message/CompletePurchaseResponse.php
@@ -36,4 +36,11 @@ class CompletePurchaseResponse extends AbstractResponse
 
         return true;
     }
+
+    public function isCancelled()
+    {
+        $data = ($this->getData());
+
+        return $data['authResult'] === 'CANCELLED';
+    }
 }

--- a/tests/Omnipay/Adyen/Message/CompletePurchaseResponseTest.php
+++ b/tests/Omnipay/Adyen/Message/CompletePurchaseResponseTest.php
@@ -69,7 +69,7 @@ class CompletePurchaseResponseTest extends TestCase
 
         $this->assertTrue($response->isSuccessful());
     }
-    
+
     public function testIsCancelled()
     {
         $response = new CompletePurchaseResponse(
@@ -80,6 +80,22 @@ class CompletePurchaseResponseTest extends TestCase
             )
         );
         $this->assertTrue($response->isCancelled());
+    }
+
+    public function testIsNotCancelled()
+    {
+        $response = new CompletePurchaseResponse(
+            $this->getMockRequest(),
+            array(
+                'success' => true,
+                'allParams' => array(
+                    'merchantSig' => 'YRTyF4SIdrW2mKIbNukCTkZ21dHCzcQYOevrBII+yUI='
+                ),
+                'responseSignature' => 'YRTyF4SIdrW2mKIbNukCTkZ21dHCzcQYOevrBII+yUI='
+            )
+        );
+
+        $this->assertFalse($response->isCancelled());
     }
 
     public function testGetResponse()

--- a/tests/Omnipay/Adyen/Message/CompletePurchaseResponseTest.php
+++ b/tests/Omnipay/Adyen/Message/CompletePurchaseResponseTest.php
@@ -98,6 +98,34 @@ class CompletePurchaseResponseTest extends TestCase
         $this->assertFalse($response->isCancelled());
     }
 
+    public function testIsPending()
+    {
+        $response = new CompletePurchaseResponse(
+            $this->getMockRequest(),
+            array(
+                'success' => false,
+                'authResult' => 'PENDING',
+            )
+        );
+        $this->assertTrue($response->isPending());
+    }
+
+    public function testIsNotPending()
+    {
+        $response = new CompletePurchaseResponse(
+            $this->getMockRequest(),
+            array(
+                'success' => true,
+                'allParams' => array(
+                    'merchantSig' => 'YRTyF4SIdrW2mKIbNukCTkZ21dHCzcQYOevrBII+yUI='
+                ),
+                'responseSignature' => 'YRTyF4SIdrW2mKIbNukCTkZ21dHCzcQYOevrBII+yUI='
+            )
+        );
+
+        $this->assertFalse($response->isPending());
+    }
+
     public function testGetResponse()
     {
         $mock = $this->getMockRequest();

--- a/tests/Omnipay/Adyen/Message/CompletePurchaseResponseTest.php
+++ b/tests/Omnipay/Adyen/Message/CompletePurchaseResponseTest.php
@@ -69,6 +69,18 @@ class CompletePurchaseResponseTest extends TestCase
 
         $this->assertTrue($response->isSuccessful());
     }
+    
+    public function testIsCancelled()
+    {
+        $response = new CompletePurchaseResponse(
+            $this->getMockRequest(),
+            array(
+                'success' => false,
+                'authResult' => 'CANCELLED',
+            )
+        );
+        $this->assertTrue($response->isCancelled());
+    }
 
     public function testGetResponse()
     {


### PR DESCRIPTION
Allows driver-agnostic omnipay systems to understand a transaction was cancelled. 